### PR TITLE
fix: circular imports

### DIFF
--- a/src/pipeline/ports/extractors.py
+++ b/src/pipeline/ports/extractors.py
@@ -1,23 +1,14 @@
 from __future__ import annotations
+from abc import ABC, abstractmethod
+from typing import Iterable
+from pipeline.domain.models import WeatherSample, EarthquakeEvent
 
-from dataclasses import dataclass
+class WeatherExtractor(ABC):
+    @abstractmethod
+    def fetch(self) -> Iterable[WeatherSample]:
+        raise NotImplementedError
 
-from pipeline.ports.extractors import WeatherExtractor
-from pipeline.ports.repositories import WeatherRepository
-
-
-@dataclass(frozen=True)
-class IngestResult:
-    fetched: int
-    upserted: int
-
-
-class IngestWeatherService:
-    def __init__(self, extractor: WeatherExtractor, repository: WeatherRepository) -> None:
-        self._extractor = extractor
-        self._repository = repository
-
-    def run(self) -> IngestResult:
-        samples = list(self._extractor.fetch())
-        upserted = self._repository.upsert_many(samples)
-        return IngestResult(fetched=len(samples), upserted=upserted)
+class EarthquakeExtractor(ABC):
+    @abstractmethod
+    def fetch(self) -> Iterable[EarthquakeEvent]:
+        raise NotImplementedError

--- a/src/pipeline/ports/repositories.py
+++ b/src/pipeline/ports/repositories.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
-
 from abc import ABC, abstractmethod
 from typing import Iterable
-
 from pipeline.domain.models import WeatherSample, EarthquakeEvent
-
 
 class WeatherRepository(ABC):
     @abstractmethod
@@ -12,7 +9,6 @@ class WeatherRepository(ABC):
         raise NotImplementedError
 
 class EarthquakeRepository(ABC):
-
     @abstractmethod
     def upsert_many(self, events: Iterable[EarthquakeEvent]) -> int:
         raise NotImplementedError


### PR DESCRIPTION
Removed service code from ports to prevent self-import issue
Kept ports/extractors as pure interfaces
Moved IngestWeatherService to services package