### PR TITLE
fix: add session decorator

### DIFF
--- a/src/pipeline/db.py
+++ b/src/pipeline/db.py
@@ -24,6 +24,7 @@ SessionLocal = sessionmaker(
 
 Base = declarative_base()
 
+@contextmanager
 def safe_session(existing_session: Optional[Session] = None) -> Iterator[Session]:
     if existing_session is not None:
         yield existing_session


### PR DESCRIPTION
- Add missing @contextmanager decorator to safe_session
- Ensures it can be used with 'with' blocks correctly
- Fixes previous generator object error during repo upserts